### PR TITLE
Fix contentPath provider is not used

### DIFF
--- a/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
+++ b/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
@@ -91,7 +91,7 @@ function Set-TargetResource
     {
         #sync the given package content into iis
         
-        if($Destination -contains "\")
+        if($Destination.Contains("\"))
         {
               #this is the case when iis site content path is specified
              $appCmd += "-verb:sync -source:package=$SourcePath -dest:contentPath=$Destination"
@@ -108,7 +108,7 @@ function Set-TargetResource
     else
     {
       #delete the website content    
-      if($Destination -contains "\")
+      if($Destination.Contains("\"))
       {
         # $SourcePath in this case points to physical path of the website.
           Remove-Item -Path $Destination -Recurse -ErrorAction SilentlyContinue 


### PR DESCRIPTION
Even if Destination is path to the content, contentProvider is not used. Fix comparison to check if Destination contains any backslash

Closes bug #4

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebdeploy/5)

<!-- Reviewable:end -->
