### PR TITLE
Fix failing build with update of appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ test_script:
         if ($res.FailedCount -gt 0) { 
             throw "$($res.FailedCount) tests failed."
         }
+        $error.Clear()
     
 #---------------------------------# 
 #      deployment configuration   # 


### PR DESCRIPTION
I've figured out the reason for the failing build following hours of debugging on the AppVeyor build workers. The PSScriptAnalyzer run pollutes the $error variable of the hosted runspace inside the AppVeyor Agent process with 100+ exceptions regarding failed module imports (nesting limit reached) which stops the build once the test script completes.

```
Cannot load the module 'C:\Windows\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\Microsoft.PowerShell.ScheduledJob.dll' because the module nesting limit has been exceeded. Modules can only be nested to 10 levels. 
Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.
Cannot load the module 'C:\Windows\system32\WindowsPowerShell\v1.0\Modules\NFS\MSFT_NfsMappedIdentity\Microsoft.FileServices.Powershell.NFS.dll' because the module nesting limit has been exceeded. Modules can only be nested to 
10 levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.
Cannot load the module 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\SQLPS\Microsoft.SqlServer.Management.PSSnapins.dll' because the module nesting limit has been exceeded. Modules can only be nested 
to 10 levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.
Cannot load the module 'C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.dll' because the module nesting limit has been exceeded. Modules can only be nested to 10 levels. Evaluate and change the order in 
which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.
Cannot load the module 'C:\Program Files (x86)\Microsoft SDKs\Azure\PowerShell\Storage\Azure.Storage\.\Microsoft.WindowsAzure.Commands.Storage.dll' because the module nesting limit has been exceeded. Modules can only be nested 
to 10 levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.
```

I've modified the test_script section of the appveyor.yml at the end to clear the $error variable. This not does impact our ability to fail the build if Pester returns a FailedCount greater than 0 because the throw statement will terminate the session before the $error.Clear().

I'll continue to investigate why we are only seeing this problem with the xWebDeploy module and the PSScriptAnalyzer.

Please let me know if you're happy to merge this PR as a workaround to be able to successfully publish xWebDeploy to the gallery.

Fixes #8 
