### PR TITLE
Issue17 comparison of files

### DIFF
--- a/DSCResources/xWebDeploy/xWebDeploy.psd1
+++ b/DSCResources/xWebDeploy/xWebDeploy.psd1
@@ -28,7 +28,7 @@ Copyright = '(c) 2014 Microsoft. All rights reserved.'
 # Description = ''
 
 # Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
+PowerShellVersion = '4.0'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''

--- a/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
+++ b/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
@@ -77,7 +77,10 @@ function Set-TargetResource
         
           [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure = "Present"
+        $Ensure = "Present",
+
+        [System.Boolean]
+        $UseAutoForDeployment = $false
     )
 
     Write-Verbose -Message "Calling msdeploy.exe to sync the site content from a given zip package"
@@ -90,16 +93,21 @@ function Set-TargetResource
     if($Ensure -eq "Present")
     {
         #sync the given package content into iis
-        
-        if($Destination.Contains("\"))
+        if ($UseAutoForDeployment)
         {
-              #this is the case when iis site content path is specified
-             $appCmd += "-verb:sync -source:package=$SourcePath -dest:contentPath=$Destination"
+            $appCmd += "-verb:sync -source:package=$SourcePath -dest:auto"
         }
-        else
-        {
-            #this is the case when iis site name is specified
-            $appCmd += "-verb:sync -source:package=$SourcePath -dest:iisApp=$Destination"           
+        else {
+            if($Destination.Contains("\"))
+            {
+                #this is the case when iis site content path is specified
+                $appCmd += "-verb:sync -source:package=$SourcePath -dest:contentPath=$Destination"
+            }
+            else
+            {
+                #this is the case when iis site name is specified
+                $appCmd += "-verb:sync -source:package=$SourcePath -dest:iisApp=$Destination"           
+            }          
         }
         Write-Verbose -Message $appCmd
         Invoke-Expression $appCmd

--- a/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
+++ b/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
@@ -74,13 +74,13 @@ function Set-TargetResource
         [parameter(Mandatory = $true)]
         [System.String]
         $Destination,
-        
-          [ValidateSet("Present","Absent")]
-        [System.String]
-        $Ensure = "Present",
 
         [System.Boolean]
-        $UseAutoForDeployment = $false
+        $UseAutoForDeployment = $false,
+        
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = "Present"
     )
 
     Write-Verbose -Message "Calling msdeploy.exe to sync the site content from a given zip package"
@@ -155,6 +155,9 @@ function Test-TargetResource
         [System.String]
         $Destination,
 
+        [System.Boolean]
+        $UseAutoForDeployment = $false,
+        
         [ValidateSet("Present","Absent")]
         [System.String]
         $Ensure = "Present"

--- a/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
+++ b/DSCResources/xWebPackageDeploy/xWebPackageDeploy.psm1
@@ -9,8 +9,7 @@
 # the package is deployed and return the result
 #########################################################################################################################################
 
-function Get-TargetResource
-{
+function Get-TargetResource {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -19,7 +18,7 @@ function Get-TargetResource
         [System.String]
         $SourcePath,
 
-       [parameter(Mandatory = $true)]
+        [parameter(Mandatory = $true)]
         [System.String]
         $Destination
     )
@@ -27,31 +26,28 @@ function Get-TargetResource
     $appCmd = "$env:PROGRAMFILES\IIS\Microsoft Web Deploy V3\msdeploy.exe"
     $ensure = "Absent"
     Write-Verbose -Message "Calling msdeploy.exe to retrieve the site content in a zip file format"
-      & $appCmd -verb:sync "-source:contentPath=$Destination" "-dest:package=$SourcePath" 
+    & $appCmd -verb:sync "-source:contentPath=$Destination" "-dest:package=$SourcePath" 
 
     # $Destination in this case points to website content full path.
-    if(Test-Path($Destination))
-    {
+    if (Test-Path($Destination)) {
         $ensure = "Present"
     }        
-    else
-    {
+    else {
         # this is the case where $Destination points to IIS website name and not the website content path
         $site = Get-ItemProperty -Path "IIS:\Sites\$Destination" -ErrorAction SilentlyContinue
-        if ($site -ne $null)
-        {
-           $path = $site.physicalPath           
-           if(Test-Path($path))
-           {
-             $ensure = "Present"
-           }
+        if ($site -ne $null) {
+            $path = $site.physicalPath           
+            if (Test-Path($path)) {
+                $ensure = "Present"
+            }
         }
     }
 
     $returnValue = @{
-    SourcePath = $SourcePath
-    Destination = $Destination            
-    Ensure = $ensure}    
+        SourcePath  = $SourcePath
+        Destination = $Destination            
+        Ensure      = $ensure
+    }    
 
     $returnValue
     
@@ -62,8 +58,7 @@ function Get-TargetResource
 # the website content
 #########################################################################################################################################
 
-function Set-TargetResource
-{
+function Set-TargetResource {
     [CmdletBinding()]
     param
     (
@@ -78,7 +73,7 @@ function Set-TargetResource
         [System.Boolean]
         $UseAutoForDeployment = $false,
         
-        [ValidateSet("Present","Absent")]
+        [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present"
     )
@@ -90,21 +85,17 @@ function Set-TargetResource
     $appCmd = Join-Path $app -ChildPath "msdeploy.exe"
     $appCmd = "& '$appCmd'"   
         
-    if($Ensure -eq "Present")
-    {
+    if ($Ensure -eq "Present") {
         #sync the given package content into iis
-        if ($UseAutoForDeployment)
-        {
+        if ($UseAutoForDeployment) {
             $appCmd += "-verb:sync -source:package=$SourcePath -dest:auto"
         }
         else {
-            if($Destination.Contains("\"))
-            {
+            if ($Destination.Contains("\")) {
                 #this is the case when iis site content path is specified
                 $appCmd += "-verb:sync -source:package=$SourcePath -dest:contentPath=$Destination"
             }
-            else
-            {
+            else {
                 #this is the case when iis site name is specified
                 $appCmd += "-verb:sync -source:package=$SourcePath -dest:iisApp=$Destination"           
             }          
@@ -113,25 +104,21 @@ function Set-TargetResource
         Invoke-Expression $appCmd
 
     }
-    else
-    {
-      #delete the website content    
-      if($Destination.Contains("\"))
-      {
-        # $SourcePath in this case points to physical path of the website.
-          Remove-Item -Path $Destination -Recurse -ErrorAction SilentlyContinue 
-      }      
-      else
-      {
-        # this is the case where $SourcePath points to IIS website name and not the actual path
-        $site = Get-ItemProperty -Path "IIS:\Sites\$Destination" -ErrorAction SilentlyContinue
-        if ($site -ne $null)
-        {
-           $path = $site.physicalPath
-           $files = Get-Item -Path $path -ErrorAction SilentlyContinue           
-           Remove-Item -Path $files -Recurse -ErrorAction SilentlyContinue 
-        }
-      }  
+    else {
+        #delete the website content    
+        if ($Destination.Contains("\")) {
+            # $SourcePath in this case points to physical path of the website.
+            Remove-Item -Path $Destination -Recurse -ErrorAction SilentlyContinue 
+        }      
+        else {
+            # this is the case where $SourcePath points to IIS website name and not the actual path
+            $site = Get-ItemProperty -Path "IIS:\Sites\$Destination" -ErrorAction SilentlyContinue
+            if ($site -ne $null) {
+                $path = $site.physicalPath
+                $files = Get-Item -Path $path -ErrorAction SilentlyContinue           
+                Remove-Item -Path $files -Recurse -ErrorAction SilentlyContinue 
+            }
+        }  
 
     }    
 }
@@ -141,8 +128,7 @@ function Set-TargetResource
 # determine whether the package is deployed or not.
 #########################################################################################################################################
 
-function Test-TargetResource
-{
+function Test-TargetResource {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -158,7 +144,7 @@ function Test-TargetResource
         [System.Boolean]
         $UseAutoForDeployment = $false,
         
-        [ValidateSet("Present","Absent")]
+        [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present"
     )
@@ -168,47 +154,64 @@ function Test-TargetResource
     #get all the files from a given package
     $packageFiles = & $appCmd -verb:dump "-source:package=$SourcePath"
  
-    if($Ensure -eq "Present")
-    {
-         #find all the files for a given site
+    if ($Ensure -eq "Present") {
+        #find all the files for a given site
         $siteFiles = & $appCmd -verb:dump "-source:contentPath=$Destination"
         # the packages exported using webdeploy tool, contain 2 extra entries with site name. Skipping those..
         #compare based on the number of files
-        if(($packageFiles.Count -eq $siteFiles.Count) -or (($packageFiles.Count -2) -eq $siteFiles.Count) )
+        if ( -not (Compare-WebDeployPackages $packageFiles $siteFiles ) )
         {
             $result = $true
-        }
-     }   
-    else
-    {       
-        #find the website's physical path if $Destination points to a site name
-        $site = Get-ItemProperty -Path "IIS:\Sites\$Destination" -ErrorAction SilentlyContinue
-        if ($site -ne $null)
-        {
-           $path = $site.physicalPath
-           $files = Get-Item -Path $path -ErrorAction SilentlyContinue
-           if ($files -ne $null)
-            {
-                $f = $files.GetFiles()
-            }
-            if($f.Count >1)
-            {
-                $result = $true
-            }            
-        }
-        #this is the case when $Destination points to the website's physical path 
+        }   
         else
-        {
-            if(Test-Path($Destination))
+        {       
+            #find the website's physical path if $Destination points to a site name
+            $site = Get-ItemProperty -Path "IIS:\Sites\$Destination" -ErrorAction SilentlyContinue
+            if ($site -ne $null) 
             {
-                $result = $true
-            } 
+                $path = $site.physicalPath
+                $files = Get-Item -Path $path -ErrorAction SilentlyContinue
+                if ($files -ne $null) 
+                {
+                    $f = $files.GetFiles()
+                }
+                if ($f.Count >1) 
+                {
+                    $result = $true
+                }            
+            }
+            #this is the case when $Destination points to the website's physical path 
+            else 
+            {
+                if (Test-Path($Destination))
+                {
+                    $result = $true
+                } 
+            }
         }
-     }
-    $result    
+        $result    
+    }
 }
 
+function Compare-WebDeployPackages {
+    param (
+        $CompareA,
+        $CompareB
+    )
 
+    # get the path from the second line of the dump from webdeploy. Replace \ with \\ (for regex search on next line)
+    $path = $CompareA[1].Replace('\', '\\')
+    # remove the path from each line, as this may be different
+    # skip the first line because that states whether it is a MSDeploy.contentPath or sitemanifest
+    # ignore any resulting empty lines
+    # sort to ensure the order is correct
+    $RelevantItemsFromA = $CompareA -replace "$path", '' | select-object -skip 1 | where-object { $_ -ne '' } | sort-object
 
+    # repeat using the other object
+    $path = $CompareB[1].Replace('\', '\\')
+    $RelevantItemsFromB = $CompareB -replace "$path", '' | select-object -skip 1 | where-object { $_ -ne '' } | sort-object
 
+    # now a standard compare-object will do the work, we just need to check for $null to ensure the two objects are unique.
+    Compare-Object $RelevantItemsFromA $RelevantItemsFromB
 
+}

--- a/DSCResources/xWebPackageDeploy/xWebPackageDeploy.schema.mof
+++ b/DSCResources/xWebPackageDeploy/xWebPackageDeploy.schema.mof
@@ -6,6 +6,7 @@ class xWebPackageDeploy : OMI_BaseResource
     [Required, Description("Full path to the zip package.")] String SourcePath;
     [Key, Description("WebDeploy destination for content path or website name).")] String Destination;    
     [Write, Description("Desired state of resource."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Use auto as the destination target")] Boolean UseAutoForDeployment;
 };
 
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Note: This composite resource requires the **Package** resource that ships with 
 * **SourcePath**: The full path on the filesystem where the web deploy package (as a zip file) is located. 
 * **Destination**: The IIS content path or IIS site name to install the WebDeploy zip package. 
 * **Ensure**: Ensures that the web package is installed: { Present | Absent }
+* **UseAutoForDeployment**: Use 'auto' as the destination provider when deploying.  The path or IIS site must still be specified in the Destination otherwise the Test- and Get- functions will not work.
 
 ## Versions
 
 ### Unreleased
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* xWebPackageDeploy: Added UseAutoForDeployment option
 
 ### 1.2.0.0
 * xWebPackageDeploy: Fixed comparison to check if Destination contains any backslash

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note: This composite resource requires the **Package** resource that ships with 
 
 ### Unreleased
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
-* xWebPackageDeploy: Added UseAutoForDeployment option
+* xWebPackageDeploy: Added UseAutoForDeployment option.
 
 ### 1.2.0.0
 * xWebPackageDeploy: Fixed comparison to check if Destination contains any backslash

--- a/ResourceSetHelper.psm1
+++ b/ResourceSetHelper.psm1
@@ -1,0 +1,227 @@
+# This module should not write any verbose or error messages unless a localization file for it is added
+
+$errorActionPreference = 'Stop'
+Set-StrictMode -Version 'Latest'
+
+<#
+    .SYNOPSIS
+        Builds a string of the common parameters shared across all resources in a set.
+    .PARAMETER KeyParameterName
+        The name of the key parameter for the resource.
+    .PARAMETER Parameters
+        The hashtable of all parameters to the resource set (PSBoundParameters).
+    .EXAMPLE
+        $parameters = @{
+            KeyParameter = @( 'MyKeyParameter1', 'MyKeyParameter2' )
+            CommonParameter1 = 'CommonValue1'
+            CommonParameter2 = 2
+        }
+        New-ResourceSetCommonParameterString -KeyParameterName 'KeyParameter' -Parameters $parameters
+        OUTPUT (as string):
+        CommonParameter1 = "CommonValue1"`r`nCommonParameter2 = $CommonParameter2
+#>
+function New-ResourceSetCommonParameterString
+{
+    [OutputType([String])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $KeyParameterName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Hashtable]
+        $Parameters
+    )
+
+    $stringBuilder = New-Object -TypeName 'System.Text.StringBuilder'
+
+    foreach ($parameterName in $Parameters.Keys) 
+    {
+        # All composite resources have an extra parameter 'InstanceName'
+        if ($parameterName -ine $KeyParameterName -and $parameterName -ine 'InstanceName')
+        {
+            $parameterValue = $Parameters[$parameterName]
+
+            if ($null -ne $parameterValue)
+            {
+                if ($parameterValue -is [String])
+                {
+                    $null = $stringBuilder.AppendFormat('{0} = "{1}"', $parameterName, $parameterValue)
+                }
+                else
+                {
+                    $null = $stringBuilder.Append($parameterName + ' = $' + $parameterName)
+                }
+
+                $null = $stringBuilder.AppendLine()
+            }
+        }
+    }
+
+    return $stringBuilder.ToString()
+}
+
+<#
+    .SYNOPSIS
+        Creates a string representing a configuration script for a set of resources.
+    .PARAMETER ResourceName
+        The name of the resource to create a set of.
+    .PARAMETER ModuleName
+        The name of the module to import the resource from.
+    .PARAMETER KeyParameterName
+        The name of the key parameter that will differentiate each resource.
+    .PARAMETER KeyParameterValues
+        An array of the values of the key parameter that will differentiate each resource.
+    .PARAMETER CommonParameterString
+        A string representing the common parameters for each resource.
+        Can be retrieved from New-ResourceSetCommonParameterString.
+    .EXAMPLE
+        New-ResourceSetConfigurationString `
+            -ResourceName 'xWindowsFeature' `
+            -ModuleName 'xPSDesiredStateConfiguration' `
+            -KeyParameterName 'Name' `
+            -KeyParameterValues @( 'Telnet-Client', 'Web-Server' ) `
+            -CommonParameterString 'Ensure = "Present"`r`nIncludeAllSubFeature = $true'
+        OUTPUT (as a String):
+            Import-Module -Name xWindowsFeature -ModuleName xPSDesiredStateConfiguration
+            xWindowsFeature Resource0
+            {
+                Name = "Telnet-Client"
+                Ensure = "Present"
+                IncludeAllSubFeature = $true
+            }  
+            xWindowsFeature Resource1
+            {
+                Name = "Web-Server"
+                Ensure = "Present"
+                IncludeAllSubFeature = $true
+            }
+#>
+function New-ResourceSetConfigurationString
+{
+    [OutputType([String])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ResourceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $KeyParameterName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String[]]
+        $KeyParameterValues, 
+    
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $CommonParameterString
+    )
+
+    $stringBuilder = New-Object -TypeName 'System.Text.StringBuilder'
+
+    $null = $stringBuilder.AppendFormat('Import-DscResource -Name {0} -ModuleName {1}', $ResourceName, $ModuleName)
+    $null = $stringBuilder.AppendLine()
+
+    $resourceCount = 0
+    foreach ($keyParameterValue in $KeyParameterValues)
+    {
+        $null = $stringBuilder.AppendFormat('{0} Resource{1}', $ResourceName, $resourceCount)
+        $null = $stringBuilder.AppendLine()
+        $null = $stringBuilder.AppendLine('{')
+        $null = $stringBuilder.AppendFormat($KeyParameterName + ' = "{0}"', $keyParameterValue)
+        $null = $stringBuilder.AppendLine()
+        $null = $stringBuilder.Append($CommonParameterString)
+        $null = $stringBuilder.AppendLine('}')
+        
+        $resourceCount++
+    }
+
+    return $stringBuilder.ToString()
+}
+
+<#
+    .SYNOPSIS
+        Creates a configuration script block for a set of resources.
+    .PARAMETER ResourceName
+        The name of the resource to create a set of.
+    .PARAMETER ModuleName
+        The name of the module to import the resource from.
+    .PARAMETER KeyParameterName
+        The name of the key parameter that will differentiate each resource.
+    .PARAMETER Parameters
+        The hashtable of all parameters to the resource set (PSBoundParameters).
+    .EXAMPLE
+        # From the xGroupSet composite resource
+        $newResourceSetConfigurationParams = @{
+            ResourceName = 'xGroup'
+            ModuleName = 'xPSDesiredStateConfiguration'
+            KeyParameterName = 'GroupName'
+            CommonParameterNames = @( 'Ensure', 'MembersToInclude', 'MembersToExclude', 'Credential' )
+            Parameters = $PSBoundParameters
+        }
+    
+        $configurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
+    .NOTES
+        Only allows one key parameter to be defined for each node.
+        For resources with multiple key parameters, only one key can be different for each resource.
+        See xProcessSet for an example of a resource set with two key parameters.
+#>
+function New-ResourceSetConfigurationScriptBlock
+{
+    [OutputType([ScriptBlock])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ResourceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $KeyParameterName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Hashtable]
+        $Parameters
+    )
+
+    $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $KeyParameterName -Parameters $Parameters
+
+    $newResourceSetConfigurationStringParams = @{
+        ResourceName = $ResourceName
+        ModuleName = $ModuleName
+        KeyParameterName = $KeyParameterName
+        KeyParameterValues = $Parameters[$KeyParameterName]
+        CommonParameterString = $commonParameterString
+    }
+
+    $resourceString = New-ResourceSetConfigurationString @newResourceSetConfigurationStringParams
+
+    return [ScriptBlock]::Create($resourceString)
+}
+
+Export-ModuleMember -Function @( 'New-ResourceSetConfigurationScriptBlock' )

--- a/xWebDeploy.psd1
+++ b/xWebDeploy.psd1
@@ -28,7 +28,7 @@ Copyright = '(c) 2014 Microsoft. All rights reserved.'
 Description = 'DSC resources for installing an IIS site using the WebDeploy IIS extension'
 
 # Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
+PowerShellVersion = '4.0'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''


### PR DESCRIPTION
This fixes #17 by ignoring differences between the parent path in the source package compared to the destination.  By doing this, it is able to more accurately determine whether the source and the destination are the same.

The difference only checks that the filenames are the same, file contents are not compared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebdeploy/18)
<!-- Reviewable:end -->
